### PR TITLE
Update entitlements path for macOS build configuration

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -69,7 +69,7 @@ nsis:
   include: windows/installer.nsh
 mac:
   artifactName: 'marktext-mac-${arch}-${version}.${ext}'
-  entitlementsInherit: mac/entitlements.mac.plist
+  entitlementsInherit: build/mac/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.


### PR DESCRIPTION
This PR corrected the path to the entitlements file in electron-builder.yml. We should be able to run the build command without errors now.

The file was located at build/mac/entitlements.mac.plist, but the build command is looking for it at mac/entitlements.mac.plist. This path mismatch was causing the error.