### PR TITLE
Fix null pointer exception in normalizeHeaderText during undo/redo

### DIFF
--- a/src/muya/lib/utils/exportMarkdown.js
+++ b/src/muya/lib/utils/exportMarkdown.js
@@ -184,6 +184,11 @@ class ExportMarkdown {
     const { text } = block.children[0]
     if (headingStyle === 'atx') {
       const match = text.match(/(#{1,6})(.*)/)
+      if (!match) {
+        // Fallback: if regex doesn't match, return text as-is
+        console.warn('normalizeHeaderText: ATX heading regex did not match:', text)
+        return `${indent}${text}\n`
+      }
       const atxHeadingText = `${match[1]} ${match[2].trim()}`
       return `${indent}${atxHeadingText}\n`
     } else if (headingStyle === 'setext') {


### PR DESCRIPTION
Fixes #23

## Problem

MarkText crashes with "TypeError: Cannot read properties of null (reading '1')" during undo/redo operations on heading blocks.

## Root Cause

The `normalizeHeaderText` method in `src/muya/lib/utils/exportMarkdown.js` attempts to access array indices `[1]` and `[2]` from a regex match result without verifying the match succeeded. When the regex fails to match (which can happen with malformed headers during undo/redo), the code tries to access properties on `null`.

## Solution

Added null check with fallback behavior:
- If regex doesn't match, log a warning and return text as-is
- This prevents the crash while still exporting the content

## Testing

Tested on macOS with multiple undo/redo operations on heading blocks. The crash no longer occurs, and content is preserved correctly.

## Files Changed

- `src/muya/lib/utils/exportMarkdown.js` - Added null safety check