### PR TITLE
Follow system theme

### DIFF
--- a/src/main/preferences/index.js
+++ b/src/main/preferences/index.js
@@ -100,6 +100,24 @@ class Preference extends EventEmitter {
           this.store.set(userSetting)
         }
       }
+
+      // Migrate old autoSwitchTheme to new followSystemTheme
+      if ('autoSwitchTheme' in userSetting && !('followSystemTheme' in userSetting)) {
+        // Convert old enum values to new boolean
+        // autoSwitchTheme: 0 = "at startup" → followSystemTheme: true
+        // autoSwitchTheme: 2 = "never" → followSystemTheme: false
+        const oldValue = userSetting.autoSwitchTheme
+        userSetting.followSystemTheme = userSetting.autoSwitchTheme === 0
+
+        // Remove old setting
+        delete userSetting.autoSwitchTheme
+        this.store.delete('autoSwitchTheme')
+
+        log.info(`Migrated autoSwitchTheme (${oldValue}) to followSystemTheme (${userSetting.followSystemTheme})`)
+
+        // Save the updated setting
+        this.store.set('followSystemTheme', userSetting.followSystemTheme)
+      }
     }
 
     this._listenForIpcMain()

--- a/src/main/preferences/index.js
+++ b/src/main/preferences/index.js
@@ -101,7 +101,7 @@ class Preference extends EventEmitter {
         }
       }
 
-      // Migrate old autoSwitchTheme to new followSystemTheme
+      // Migrate old autoSwitchTheme to new followSystemTheme with separate light/dark themes
       if ('autoSwitchTheme' in userSetting && !('followSystemTheme' in userSetting)) {
         // Convert old enum values to new boolean
         // autoSwitchTheme: 0 = "at startup" → followSystemTheme: true
@@ -109,14 +109,38 @@ class Preference extends EventEmitter {
         const oldValue = userSetting.autoSwitchTheme
         userSetting.followSystemTheme = userSetting.autoSwitchTheme === 0
 
+        // Set default theme preferences for light and dark modes
+        if (!('lightModeTheme' in userSetting)) {
+          userSetting.lightModeTheme = 'light'
+        }
+        if (!('darkModeTheme' in userSetting)) {
+          // If current theme is a dark theme, use it; otherwise default to 'dark'
+          const currentTheme = userSetting.theme || 'light'
+          const isDarkTheme = /dark/i.test(currentTheme)
+          userSetting.darkModeTheme = isDarkTheme ? currentTheme : 'dark'
+        }
+
         // Remove old setting
         delete userSetting.autoSwitchTheme
         this.store.delete('autoSwitchTheme')
 
         log.info(`Migrated autoSwitchTheme (${oldValue}) to followSystemTheme (${userSetting.followSystemTheme})`)
+        log.info(`  lightModeTheme: ${userSetting.lightModeTheme}, darkModeTheme: ${userSetting.darkModeTheme}`)
 
-        // Save the updated setting
+        // Save the updated settings
         this.store.set('followSystemTheme', userSetting.followSystemTheme)
+        this.store.set('lightModeTheme', userSetting.lightModeTheme)
+        this.store.set('darkModeTheme', userSetting.darkModeTheme)
+      }
+
+      // Add defaults for new users (users without autoSwitchTheme to migrate)
+      if (!('lightModeTheme' in userSetting)) {
+        userSetting.lightModeTheme = 'light'
+        this.store.set('lightModeTheme', 'light')
+      }
+      if (!('darkModeTheme' in userSetting)) {
+        userSetting.darkModeTheme = 'dark'
+        this.store.set('darkModeTheme', 'dark')
       }
     }
 

--- a/src/main/preferences/index.js
+++ b/src/main/preferences/index.js
@@ -100,48 +100,6 @@ class Preference extends EventEmitter {
           this.store.set(userSetting)
         }
       }
-
-      // Migrate old autoSwitchTheme to new followSystemTheme with separate light/dark themes
-      if ('autoSwitchTheme' in userSetting && !('followSystemTheme' in userSetting)) {
-        // Convert old enum values to new boolean
-        // autoSwitchTheme: 0 = "at startup" → followSystemTheme: true
-        // autoSwitchTheme: 2 = "never" → followSystemTheme: false
-        const oldValue = userSetting.autoSwitchTheme
-        userSetting.followSystemTheme = userSetting.autoSwitchTheme === 0
-
-        // Set default theme preferences for light and dark modes
-        if (!('lightModeTheme' in userSetting)) {
-          userSetting.lightModeTheme = 'light'
-        }
-        if (!('darkModeTheme' in userSetting)) {
-          // If current theme is a dark theme, use it; otherwise default to 'dark'
-          const currentTheme = userSetting.theme || 'light'
-          const isDarkTheme = /dark/i.test(currentTheme)
-          userSetting.darkModeTheme = isDarkTheme ? currentTheme : 'dark'
-        }
-
-        // Remove old setting
-        delete userSetting.autoSwitchTheme
-        this.store.delete('autoSwitchTheme')
-
-        log.info(`Migrated autoSwitchTheme (${oldValue}) to followSystemTheme (${userSetting.followSystemTheme})`)
-        log.info(`  lightModeTheme: ${userSetting.lightModeTheme}, darkModeTheme: ${userSetting.darkModeTheme}`)
-
-        // Save the updated settings
-        this.store.set('followSystemTheme', userSetting.followSystemTheme)
-        this.store.set('lightModeTheme', userSetting.lightModeTheme)
-        this.store.set('darkModeTheme', userSetting.darkModeTheme)
-      }
-
-      // Add defaults for new users (users without autoSwitchTheme to migrate)
-      if (!('lightModeTheme' in userSetting)) {
-        userSetting.lightModeTheme = 'light'
-        this.store.set('lightModeTheme', 'light')
-      }
-      if (!('darkModeTheme' in userSetting)) {
-        userSetting.darkModeTheme = 'dark'
-        this.store.set('darkModeTheme', 'dark')
-      }
     }
 
     this._listenForIpcMain()

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -320,14 +320,10 @@
     "type": "string",
     "default": "light"
   },
-  "autoSwitchTheme": {
-    "description": "Theme--Automatically adjust application theme according system.",
-    "default": 2,
-    "enum": [
-      0,
-      1,
-      2
-    ]
+  "followSystemTheme": {
+    "description": "Theme--Follow system theme (light/dark).",
+    "type": "boolean",
+    "default": false
   },
   "customCss": {
     "description": "Custom CSS--Custom CSS to apply to the current theme.",

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -321,9 +321,19 @@
     "default": "light"
   },
   "followSystemTheme": {
-    "description": "Theme--Follow system theme (light/dark).",
+    "description": "Theme--Use separate theme in dark mode.",
     "type": "boolean",
     "default": false
+  },
+  "lightModeTheme": {
+    "description": "Theme--Theme to use when system is in light mode.",
+    "type": "string",
+    "default": "light"
+  },
+  "darkModeTheme": {
+    "description": "Theme--Theme to use when system is in dark mode.",
+    "type": "string",
+    "default": "dark"
   },
   "customCss": {
     "description": "Custom CSS--Custom CSS to apply to the current theme.",

--- a/src/renderer/src/prefComponents/theme/config.js
+++ b/src/renderer/src/prefComponents/theme/config.js
@@ -21,16 +21,5 @@ export const themes = [
   }
 ]
 
-export const getAutoSwitchThemeOptions = () => [
-  {
-    label: t('preferences.theme.autoSwitchOptions.startup'),
-    value: 0
-  },
-  /* {
-  label: 'Only at runtime',
-  value: 1
-}, */ {
-    label: t('preferences.theme.autoSwitchOptions.never'),
-    value: 2
-  }
-]
+// getAutoSwitchThemeOptions removed - no longer needed
+// We now use a boolean toggle for followSystemTheme instead of a dropdown

--- a/src/renderer/src/prefComponents/theme/index.vue
+++ b/src/renderer/src/prefComponents/theme/index.vue
@@ -6,18 +6,47 @@
         v-for="t of themes"
         :key="t.name"
         class="theme"
-        :class="[t.name, { active: t.name === theme }]"
-        @click="onSelectChange('theme', t.name)"
+        :class="[
+          t.name,
+          {
+            active: t.name === theme,
+            disabled: followSystemTheme
+          }
+        ]"
+        @click="!followSystemTheme && onSelectChange('theme', t.name)"
       >
         <div v-html="t.html"></div>
       </div>
     </section>
     <separator></separator>
+
     <Bool
       :description="t('preferences.theme.followSystemTheme')"
       :bool="followSystemTheme"
       :on-change="(value) => onSelectChange('followSystemTheme', value)"
     />
+
+    <compound v-if="followSystemTheme">
+      <template #head>
+        <h6 class="title">{{ t('preferences.theme.modeThemes') }}</h6>
+      </template>
+      <template #children>
+        <cur-select
+          :description="t('preferences.theme.lightModeTheme')"
+          :value="lightModeTheme"
+          :options="themeOptions"
+          :on-change="(value) => onSelectChange('lightModeTheme', value)"
+        ></cur-select>
+
+        <cur-select
+          :description="t('preferences.theme.darkModeTheme')"
+          :value="darkModeTheme"
+          :options="themeOptions"
+          :on-change="(value) => onSelectChange('darkModeTheme', value)"
+        ></cur-select>
+      </template>
+    </compound>
+
     <div>
       <div style="font-size: smaller; color: var(--editorColor)">{{ t('preferences.theme.customCss') }}</div>
       <textarea
@@ -56,14 +85,25 @@ import themeMd from './theme.md?raw'
 import { themes as configThemes } from './config'
 import markdownToHtml from '@/util/markdownToHtml'
 import Bool from '../common/bool'
+import CurSelect from '../common/select'
 import Separator from '../common/separator'
+import Compound from '../common/compound'
 
 const themes = ref([])
 
 const { t } = useI18n()
 const preferenceStore = usePreferencesStore()
 
-const { followSystemTheme, theme, customCss } = storeToRefs(preferenceStore)
+const { followSystemTheme, lightModeTheme, darkModeTheme, theme, customCss } = storeToRefs(preferenceStore)
+
+const themeOptions = [
+  { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
+  { label: 'Material Dark', value: 'material-dark' },
+  { label: 'One Dark', value: 'one-dark' },
+  { label: 'Ulysses', value: 'ulysses' },
+  { label: 'Graphite', value: 'graphite' }
+]
 
 onMounted(async () => {
   const newThemes = []
@@ -99,6 +139,8 @@ const onSelectChange = (type, value) => {
     box-sizing: border-box;
     box-shadow: 0 9px 28px -9px rgba(0, 0, 0, 0.4);
     border-radius: 5px;
+    transition: opacity 0.2s ease;
+
     &.dark {
       color: rgba(255, 255, 255, 0.7);
       background: #282828;
@@ -141,9 +183,24 @@ const onSelectChange = (type, value) => {
         color: rgb(12, 139, 186);
       }
     }
-  }
-  & .theme.active {
-    box-shadow: var(--floatShadow);
+
+    /* Disabled state when followSystemTheme is on */
+    &.disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    /* Active theme - use outline instead of border to avoid layout shift? */
+    &.active {
+      box-shadow: var(--floatShadow);
+      outline: 2px solid var(--themeColor);
+      outline-offset: -2px;
+    }
+
+    /* Active + disabled: slightly more visible */
+    &.disabled.active {
+      opacity: 0.7;
+    }
   }
   & h3 {
     margin: 0;
@@ -166,6 +223,7 @@ const onSelectChange = (type, value) => {
     font-size: 12px;
   }
 }
+
 .import-themes {
   padding: 10px 0;
   display: flex;

--- a/src/renderer/src/prefComponents/theme/index.vue
+++ b/src/renderer/src/prefComponents/theme/index.vue
@@ -13,12 +13,11 @@
       </div>
     </section>
     <separator></separator>
-    <cur-select
-      :description="t('preferences.theme.autoSwitch')"
-      :value="autoSwitchTheme"
-      :options="getAutoSwitchThemeOptions()"
-      :on-change="(value) => onSelectChange('autoSwitchTheme', value)"
-    ></cur-select>
+    <Bool
+      :description="t('preferences.theme.followSystemTheme')"
+      :bool="followSystemTheme"
+      :on-change="(value) => onSelectChange('followSystemTheme', value)"
+    />
     <div>
       <div style="font-size: smaller; color: var(--editorColor)">{{ t('preferences.theme.customCss') }}</div>
       <textarea
@@ -54,9 +53,9 @@ import { usePreferencesStore } from '@/store/preferences'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import themeMd from './theme.md?raw'
-import { getAutoSwitchThemeOptions, themes as configThemes } from './config'
+import { themes as configThemes } from './config'
 import markdownToHtml from '@/util/markdownToHtml'
-import CurSelect from '../common/select'
+import Bool from '../common/bool'
 import Separator from '../common/separator'
 
 const themes = ref([])
@@ -64,7 +63,7 @@ const themes = ref([])
 const { t } = useI18n()
 const preferenceStore = usePreferencesStore()
 
-const { autoSwitchTheme, theme, customCss } = storeToRefs(preferenceStore)
+const { followSystemTheme, theme, customCss } = storeToRefs(preferenceStore)
 
 onMounted(async () => {
   const newThemes = []

--- a/src/renderer/src/prefComponents/theme/index.vue
+++ b/src/renderer/src/prefComponents/theme/index.vue
@@ -96,14 +96,13 @@ const preferenceStore = usePreferencesStore()
 
 const { followSystemTheme, lightModeTheme, darkModeTheme, theme, customCss } = storeToRefs(preferenceStore)
 
-const themeOptions = [
-  { label: 'Light', value: 'light' },
-  { label: 'Dark', value: 'dark' },
-  { label: 'Material Dark', value: 'material-dark' },
-  { label: 'One Dark', value: 'one-dark' },
-  { label: 'Ulysses', value: 'ulysses' },
-  { label: 'Graphite', value: 'graphite' }
-]
+// Generate dropdown options from configThemes
+const themeOptions = configThemes.map(theme => ({
+  label: theme.name.split('-').map(word =>
+    word.charAt(0).toUpperCase() + word.slice(1)
+  ).join(' '),
+  value: theme.name
+}))
 
 onMounted(async () => {
   const newThemes = []

--- a/src/renderer/src/store/preferences.js
+++ b/src/renderer/src/store/preferences.js
@@ -57,7 +57,7 @@ export const usePreferencesStore = defineStore('preferences', {
     sequenceTheme: 'hand',
 
     theme: 'light',
-    followSystemTheme: false,
+    followSystemTheme: true,
     lightModeTheme: 'light',
     darkModeTheme: 'dark',
     customCss: '',

--- a/src/renderer/src/store/preferences.js
+++ b/src/renderer/src/store/preferences.js
@@ -57,7 +57,7 @@ export const usePreferencesStore = defineStore('preferences', {
     sequenceTheme: 'hand',
 
     theme: 'light',
-    autoSwitchTheme: 2,
+    followSystemTheme: false,
     customCss: '',
 
     spellcheckerEnabled: false,

--- a/src/renderer/src/store/preferences.js
+++ b/src/renderer/src/store/preferences.js
@@ -58,6 +58,8 @@ export const usePreferencesStore = defineStore('preferences', {
 
     theme: 'light',
     followSystemTheme: false,
+    lightModeTheme: 'light',
+    darkModeTheme: 'dark',
     customCss: '',
 
     spellcheckerEnabled: false,

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -422,7 +422,7 @@
         "isGitlabCompatibilityEnabled": "GitLab-Kompatibilitätsmodus aktivieren",
         "sequenceTheme": "Sequenzdiagramm-Theme",
         "theme": "Das in MarkText verwendete Theme auswählen",
-        "autoSwitchTheme": "Anwendungs-Theme automatisch an das System anpassen",
+        "followSystemTheme": "System-Theme folgen (hell/dunkel)",
         "customCss": "Benutzerdefiniertes CSS für das aktuelle Theme",
         "spellcheckerEnabled": "Ob Rechtschreibprüfung aktiviert ist",
         "spellcheckerNoUnderline": "Rechtschreibfehler nicht unterstreichen",
@@ -795,27 +795,12 @@
     "theme": {
       "title": "Design",
       "theme": "Design",
-      "autoSwitchTheme": {
-        "title": "Automatischer Design-Wechsel",
-        "description": "Design automatisch entsprechend dem System wechseln",
-        "followSystem": "System folgen",
-        "light": "Hell",
-        "dark": "Dunkel"
-      },
-      "realTime": {
-        "title": "Echtzeit",
-        "description": "Design-Wechsel in Echtzeit"
-      },
+      "followSystemTheme": "System-Theme folgen",
       "codeBlockTheme": {
         "title": "Code-Block-Design",
         "description": "Design für Code-Blöcke"
       },
       "customCss": "Benutzerdefiniertes CSS",
-      "autoSwitchOptions": {
-        "startup": "Beim Start",
-        "never": "Niemals"
-      },
-      "autoSwitch": "Automatischer Design-Wechsel",
       "importCustomThemes": "Benutzerdefinierte Designs importieren",
       "importTheme": "Design importieren",
       "openFolder": "Ordner öffnen",

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -422,7 +422,9 @@
         "isGitlabCompatibilityEnabled": "GitLab-Kompatibilitätsmodus aktivieren",
         "sequenceTheme": "Sequenzdiagramm-Theme",
         "theme": "Das in MarkText verwendete Theme auswählen",
-        "followSystemTheme": "System-Theme folgen (hell/dunkel)",
+        "followSystemTheme": "Separates Design im Dunkelmodus verwenden",
+        "lightModeTheme": "Design, das verwendet werden soll, wenn sich das System im hellen Modus befindet",
+        "darkModeTheme": "Design, das verwendet werden soll, wenn sich das System im dunklen Modus befindet",
         "customCss": "Benutzerdefiniertes CSS für das aktuelle Theme",
         "spellcheckerEnabled": "Ob Rechtschreibprüfung aktiviert ist",
         "spellcheckerNoUnderline": "Rechtschreibfehler nicht unterstreichen",
@@ -795,12 +797,15 @@
     "theme": {
       "title": "Design",
       "theme": "Design",
-      "followSystemTheme": "System-Theme folgen",
+      "followSystemTheme": "Separates Design im Dunkelmodus verwenden",
+      "modeThemes": "Design-Auswahl",
+      "lightModeTheme": "Helles Modus-Design",
+      "darkModeTheme": "Dunkles Modus-Design",
+      "customCss": "Benutzerdefiniertes CSS",
       "codeBlockTheme": {
         "title": "Code-Block-Design",
         "description": "Design für Code-Blöcke"
       },
-      "customCss": "Benutzerdefiniertes CSS",
       "importCustomThemes": "Benutzerdefinierte Designs importieren",
       "importTheme": "Design importieren",
       "openFolder": "Ordner öffnen",

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -422,7 +422,7 @@
         "isGitlabCompatibilityEnabled": "GitLab-Kompatibilitätsmodus aktivieren",
         "sequenceTheme": "Sequenzdiagramm-Theme",
         "theme": "Das in MarkText verwendete Theme auswählen",
-        "followSystemTheme": "Separates Design im Dunkelmodus verwenden",
+        "followSystemTheme": "Systemdesign folgen",
         "lightModeTheme": "Design, das verwendet werden soll, wenn sich das System im hellen Modus befindet",
         "darkModeTheme": "Design, das verwendet werden soll, wenn sich das System im dunklen Modus befindet",
         "customCss": "Benutzerdefiniertes CSS für das aktuelle Theme",
@@ -797,7 +797,7 @@
     "theme": {
       "title": "Design",
       "theme": "Design",
-      "followSystemTheme": "Separates Design im Dunkelmodus verwenden",
+      "followSystemTheme": "Systemdesign folgen",
       "modeThemes": "Design-Auswahl",
       "lightModeTheme": "Helles Modus-Design",
       "darkModeTheme": "Dunkles Modus-Design",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -806,7 +806,6 @@
         "title": "Code block theme",
         "description": "Theme for code blocks"
       },
-      "customCss": "Custom CSS",
       "importCustomThemes": "Import custom themes",
       "importTheme": "Import Theme",
       "openFolder": "Open Folder",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -422,7 +422,7 @@
         "isGitlabCompatibilityEnabled": "Enable GitLab compatibility mode",
         "sequenceTheme": "Sequence diagram theme",
         "theme": "Select the theme used in MarkText",
-        "followSystemTheme": "Use separate theme in dark mode",
+        "followSystemTheme": "Follow System Theme",
         "lightModeTheme": "Theme to use when system is in light mode",
         "darkModeTheme": "Theme to use when system is in dark mode",
         "customCss": "Custom CSS to apply to the current theme",
@@ -797,7 +797,7 @@
     "theme": {
       "title": "Theme",
       "theme": "Theme",
-      "followSystemTheme": "Use separate theme in dark mode",
+      "followSystemTheme": "Follow System Theme",
       "modeThemes": "Theme Selection",
       "lightModeTheme": "Light mode theme",
       "darkModeTheme": "Dark mode theme",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -422,7 +422,9 @@
         "isGitlabCompatibilityEnabled": "Enable GitLab compatibility mode",
         "sequenceTheme": "Sequence diagram theme",
         "theme": "Select the theme used in MarkText",
-        "followSystemTheme": "Follow system theme (light/dark)",
+        "followSystemTheme": "Use separate theme in dark mode",
+        "lightModeTheme": "Theme to use when system is in light mode",
+        "darkModeTheme": "Theme to use when system is in dark mode",
         "customCss": "Custom CSS to apply to the current theme",
         "spellcheckerEnabled": "Whether spell checking is enabled",
         "spellcheckerNoUnderline": "Don't underline spelling mistakes",
@@ -795,7 +797,11 @@
     "theme": {
       "title": "Theme",
       "theme": "Theme",
-      "followSystemTheme": "Follow system theme",
+      "followSystemTheme": "Use separate theme in dark mode",
+      "modeThemes": "Theme Selection",
+      "lightModeTheme": "Light mode theme",
+      "darkModeTheme": "Dark mode theme",
+      "customCss": "Custom CSS",
       "codeBlockTheme": {
         "title": "Code block theme",
         "description": "Theme for code blocks"

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -422,7 +422,7 @@
         "isGitlabCompatibilityEnabled": "Enable GitLab compatibility mode",
         "sequenceTheme": "Sequence diagram theme",
         "theme": "Select the theme used in MarkText",
-        "autoSwitchTheme": "Automatically adjust application theme according system",
+        "followSystemTheme": "Follow system theme (light/dark)",
         "customCss": "Custom CSS to apply to the current theme",
         "spellcheckerEnabled": "Whether spell checking is enabled",
         "spellcheckerNoUnderline": "Don't underline spelling mistakes",
@@ -795,27 +795,12 @@
     "theme": {
       "title": "Theme",
       "theme": "Theme",
-      "autoSwitchTheme": {
-        "title": "Auto switch theme",
-        "description": "Automatically switch theme based on system",
-        "followSystem": "Follow system",
-        "light": "Light",
-        "dark": "Dark"
-      },
-      "realTime": {
-        "title": "Real time",
-        "description": "Real time theme switching"
-      },
+      "followSystemTheme": "Follow system theme",
       "codeBlockTheme": {
         "title": "Code block theme",
         "description": "Theme for code blocks"
       },
       "customCss": "Custom CSS",
-      "autoSwitchOptions": {
-        "startup": "At startup",
-        "never": "Never"
-      },
-      "autoSwitch": "Auto switch theme",
       "importCustomThemes": "Import custom themes",
       "importTheme": "Import Theme",
       "openFolder": "Open Folder",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -422,7 +422,9 @@
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidad GitLab",
         "sequenceTheme": "Tema del diagrama de secuencia",
         "theme": "Seleccionar el tema usado en MarkText",
-        "followSystemTheme": "Seguir tema del sistema (claro/oscuro)",
+        "followSystemTheme": "Usar tema separado en modo oscuro",
+        "lightModeTheme": "Tema a usar cuando el sistema está en modo claro",
+        "darkModeTheme": "Tema a usar cuando el sistema está en modo oscuro",
         "customCss": "CSS personalizado para aplicar al tema actual",
         "spellcheckerEnabled": "Si la verificación ortográfica está habilitada",
         "spellcheckerNoUnderline": "No subrayar errores ortográficos",
@@ -795,12 +797,15 @@
     "theme": {
       "title": "Tema",
       "theme": "Tema",
-      "followSystemTheme": "Seguir tema del sistema",
+      "followSystemTheme": "Usar tema separado en modo oscuro",
+      "modeThemes": "Selección de Tema",
+      "lightModeTheme": "Tema de modo claro",
+      "darkModeTheme": "Tema de modo oscuro",
+      "customCss": "CSS Personalizado",
       "codeBlockTheme": {
         "title": "Tema de bloque de código",
         "description": "Tema para bloques de código"
       },
-      "customCss": "CSS Personalizado",
       "importCustomThemes": "Importar temas personalizados",
       "importTheme": "Importar Tema",
       "openFolder": "Abrir Carpeta",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -422,7 +422,7 @@
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidad GitLab",
         "sequenceTheme": "Tema del diagrama de secuencia",
         "theme": "Seleccionar el tema usado en MarkText",
-        "followSystemTheme": "Usar tema separado en modo oscuro",
+        "followSystemTheme": "Seguir tema del sistema",
         "lightModeTheme": "Tema a usar cuando el sistema está en modo claro",
         "darkModeTheme": "Tema a usar cuando el sistema está en modo oscuro",
         "customCss": "CSS personalizado para aplicar al tema actual",
@@ -797,7 +797,7 @@
     "theme": {
       "title": "Tema",
       "theme": "Tema",
-      "followSystemTheme": "Usar tema separado en modo oscuro",
+      "followSystemTheme": "Seguir tema del sistema",
       "modeThemes": "Selección de Tema",
       "lightModeTheme": "Tema de modo claro",
       "darkModeTheme": "Tema de modo oscuro",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -422,7 +422,7 @@
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidad GitLab",
         "sequenceTheme": "Tema del diagrama de secuencia",
         "theme": "Seleccionar el tema usado en MarkText",
-        "autoSwitchTheme": "Ajustar automáticamente el tema de la aplicación según el sistema",
+        "followSystemTheme": "Seguir tema del sistema (claro/oscuro)",
         "customCss": "CSS personalizado para aplicar al tema actual",
         "spellcheckerEnabled": "Si la verificación ortográfica está habilitada",
         "spellcheckerNoUnderline": "No subrayar errores ortográficos",
@@ -795,27 +795,12 @@
     "theme": {
       "title": "Tema",
       "theme": "Tema",
-      "autoSwitchTheme": {
-        "title": "Cambio automático de tema",
-        "description": "Cambiar tema automáticamente basado en el sistema",
-        "followSystem": "Seguir sistema",
-        "light": "Claro",
-        "dark": "Oscuro"
-      },
-      "realTime": {
-        "title": "Tiempo real",
-        "description": "Cambio de tema en tiempo real"
-      },
+      "followSystemTheme": "Seguir tema del sistema",
       "codeBlockTheme": {
         "title": "Tema de bloque de código",
         "description": "Tema para bloques de código"
       },
       "customCss": "CSS Personalizado",
-      "autoSwitchOptions": {
-        "startup": "Al inicio",
-        "never": "Nunca"
-      },
-      "autoSwitch": "Cambio automático de tema",
       "importCustomThemes": "Importar temas personalizados",
       "importTheme": "Importar Tema",
       "openFolder": "Abrir Carpeta",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "Activer le mode de compatibilité GitLab",
         "sequenceTheme": "Thème du diagramme de séquence",
         "theme": "Sélectionner le thème utilisé dans MarkText",
-        "followSystemTheme": "Utiliser un thème séparé en mode sombre",
+        "followSystemTheme": "Suivre le thème du système",
         "lightModeTheme": "Thème à utiliser lorsque le système est en mode clair",
         "darkModeTheme": "Thème à utiliser lorsque le système est en mode sombre",
         "customCss": "CSS personnalisé à appliquer au thème actuel",
@@ -799,7 +799,7 @@
     "theme": {
       "title": "Thème",
       "theme": "Thème",
-      "followSystemTheme": "Utiliser un thème séparé en mode sombre",
+      "followSystemTheme": "Suivre le thème du système",
       "modeThemes": "Sélection du thème",
       "lightModeTheme": "Thème en mode clair",
       "darkModeTheme": "Thème en mode sombre",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -423,7 +423,9 @@
         "isGitlabCompatibilityEnabled": "Activer le mode de compatibilité GitLab",
         "sequenceTheme": "Thème du diagramme de séquence",
         "theme": "Sélectionner le thème utilisé dans MarkText",
-        "followSystemTheme": "Suivre le thème du système (clair/sombre)",
+        "followSystemTheme": "Utiliser un thème séparé en mode sombre",
+        "lightModeTheme": "Thème à utiliser lorsque le système est en mode clair",
+        "darkModeTheme": "Thème à utiliser lorsque le système est en mode sombre",
         "customCss": "CSS personnalisé à appliquer au thème actuel",
         "spellcheckerEnabled": "La vérification orthographique est-elle activée",
         "spellcheckerNoUnderline": "Ne pas souligner les erreurs d'orthographe",
@@ -797,12 +799,15 @@
     "theme": {
       "title": "Thème",
       "theme": "Thème",
-      "followSystemTheme": "Suivre le thème du système",
+      "followSystemTheme": "Utiliser un thème séparé en mode sombre",
+      "modeThemes": "Sélection du thème",
+      "lightModeTheme": "Thème en mode clair",
+      "darkModeTheme": "Thème en mode sombre",
+      "customCss": "CSS personnalisé",
       "codeBlockTheme": {
         "title": "Thème de bloc de code",
         "description": "Thème pour les blocs de code"
       },
-      "customCss": "CSS personnalisé",
       "importCustomThemes": "Importer des thèmes personnalisés",
       "importTheme": "Importer un thème",
       "openFolder": "Ouvrir le dossier",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "Activer le mode de compatibilité GitLab",
         "sequenceTheme": "Thème du diagramme de séquence",
         "theme": "Sélectionner le thème utilisé dans MarkText",
-        "autoSwitchTheme": "Ajuster automatiquement le thème de l'application selon le système",
+        "followSystemTheme": "Suivre le thème du système (clair/sombre)",
         "customCss": "CSS personnalisé à appliquer au thème actuel",
         "spellcheckerEnabled": "La vérification orthographique est-elle activée",
         "spellcheckerNoUnderline": "Ne pas souligner les erreurs d'orthographe",
@@ -797,27 +797,12 @@
     "theme": {
       "title": "Thème",
       "theme": "Thème",
-      "autoSwitchTheme": {
-        "title": "Changement automatique de thème",
-        "description": "Changer automatiquement de thème selon le système",
-        "followSystem": "Suivre le système",
-        "light": "Clair",
-        "dark": "Sombre"
-      },
-      "realTime": {
-        "title": "Temps réel",
-        "description": "Changement de thème en temps réel"
-      },
+      "followSystemTheme": "Suivre le thème du système",
       "codeBlockTheme": {
         "title": "Thème de bloc de code",
         "description": "Thème pour les blocs de code"
       },
       "customCss": "CSS personnalisé",
-      "autoSwitchOptions": {
-        "startup": "Au démarrage",
-        "never": "Jamais"
-      },
-      "autoSwitch": "Changement automatique de thème",
       "importCustomThemes": "Importer des thèmes personnalisés",
       "importTheme": "Importer un thème",
       "openFolder": "Ouvrir le dossier",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "GitLab互換モードを有効にする",
         "sequenceTheme": "シーケンス図のテーマ",
         "theme": "MarkTextで使用するテーマを選択",
-        "autoSwitchTheme": "システムに応じてアプリケーションテーマを自動調整",
+        "followSystemTheme": "システムテーマに従う(ライト/ダーク)",
         "customCss": "現在のテーマに適用するカスタムCSS",
         "spellcheckerEnabled": "スペルチェックが有効かどうか",
         "spellcheckerNoUnderline": "スペルミスに下線を引かない",
@@ -797,27 +797,12 @@
     "theme": {
       "title": "テーマ",
       "theme": "テーマ",
-      "autoSwitchTheme": {
-        "title": "自動テーマ切り替え",
-        "description": "システムに従ってテーマを自動切り替え",
-        "followSystem": "システムに従う",
-        "light": "ライト",
-        "dark": "ダーク"
-      },
-      "realTime": {
-        "title": "リアルタイム",
-        "description": "リアルタイムテーマ切り替え"
-      },
+      "followSystemTheme": "システムテーマに従う",
       "codeBlockTheme": {
         "title": "コードブロックテーマ",
         "description": "コードブロックのテーマ"
       },
       "customCss": "カスタムCSS",
-      "autoSwitchOptions": {
-        "startup": "起動時",
-        "never": "なし"
-      },
-      "autoSwitch": "自動テーマ切り替え",
       "importCustomThemes": "カスタムテーマをインポート",
       "importTheme": "テーマをインポート",
       "openFolder": "フォルダを開く",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -423,7 +423,9 @@
         "isGitlabCompatibilityEnabled": "GitLab互換モードを有効にする",
         "sequenceTheme": "シーケンス図のテーマ",
         "theme": "MarkTextで使用するテーマを選択",
-        "followSystemTheme": "システムテーマに従う(ライト/ダーク)",
+        "followSystemTheme": "ダークモードで別のテーマを使用",
+        "lightModeTheme": "システムがライトモードの時に使用するテーマ",
+        "darkModeTheme": "システムがダークモードの時に使用するテーマ",
         "customCss": "現在のテーマに適用するカスタムCSS",
         "spellcheckerEnabled": "スペルチェックが有効かどうか",
         "spellcheckerNoUnderline": "スペルミスに下線を引かない",
@@ -797,12 +799,15 @@
     "theme": {
       "title": "テーマ",
       "theme": "テーマ",
-      "followSystemTheme": "システムテーマに従う",
+      "followSystemTheme": "ダークモードで別のテーマを使用",
+      "modeThemes": "テーマの選択",
+      "lightModeTheme": "ライトモードのテーマ",
+      "darkModeTheme": "ダークモードのテーマ",
+      "customCss": "カスタムCSS",
       "codeBlockTheme": {
         "title": "コードブロックテーマ",
         "description": "コードブロックのテーマ"
       },
-      "customCss": "カスタムCSS",
       "importCustomThemes": "カスタムテーマをインポート",
       "importTheme": "テーマをインポート",
       "openFolder": "フォルダを開く",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "GitLab互換モードを有効にする",
         "sequenceTheme": "シーケンス図のテーマ",
         "theme": "MarkTextで使用するテーマを選択",
-        "followSystemTheme": "ダークモードで別のテーマを使用",
+        "followSystemTheme": "システムのテーマに従う",
         "lightModeTheme": "システムがライトモードの時に使用するテーマ",
         "darkModeTheme": "システムがダークモードの時に使用するテーマ",
         "customCss": "現在のテーマに適用するカスタムCSS",
@@ -799,7 +799,7 @@
     "theme": {
       "title": "テーマ",
       "theme": "テーマ",
-      "followSystemTheme": "ダークモードで別のテーマを使用",
+      "followSystemTheme": "システムのテーマに従う",
       "modeThemes": "テーマの選択",
       "lightModeTheme": "ライトモードのテーマ",
       "darkModeTheme": "ダークモードのテーマ",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "GitLab 호환 모드 활성화",
         "sequenceTheme": "시퀀스 다이어그램 테마",
         "theme": "MarkText에서 사용할 테마 선택",
-        "autoSwitchTheme": "시스템에 따라 애플리케이션 테마 자동 조정",
+        "followSystemTheme": "시스템 테마 따르기(밝게/어둡게)",
         "customCss": "현재 테마에 적용할 사용자 정의 CSS",
         "spellcheckerEnabled": "맞춤법 검사가 활성화되어 있는지 여부",
         "spellcheckerNoUnderline": "맞춤법 오류에 밑줄을 그지 않음",
@@ -797,27 +797,12 @@
     "theme": {
       "title": "테마",
       "theme": "테마",
-      "autoSwitchTheme": {
-        "title": "테마 자동 전환",
-        "description": "시스템에 따라 테마 자동 전환",
-        "followSystem": "시스템 따르기",
-        "light": "밝게",
-        "dark": "어둡게"
-      },
-      "realTime": {
-        "title": "실시간",
-        "description": "실시간 테마 전환"
-      },
+      "followSystemTheme": "시스템 테마 따르기",
       "codeBlockTheme": {
         "title": "코드 블록 테마",
         "description": "코드 블록용 테마"
       },
       "customCss": "사용자 정의 CSS",
-      "autoSwitchOptions": {
-        "startup": "시작 시",
-        "never": "안 함"
-      },
-      "autoSwitch": "테마 자동 전환",
       "importCustomThemes": "사용자 정의 테마 가져오기",
       "importTheme": "테마 가져오기",
       "openFolder": "폴더 열기",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -423,7 +423,9 @@
         "isGitlabCompatibilityEnabled": "GitLab 호환 모드 활성화",
         "sequenceTheme": "시퀀스 다이어그램 테마",
         "theme": "MarkText에서 사용할 테마 선택",
-        "followSystemTheme": "시스템 테마 따르기(밝게/어둡게)",
+        "followSystemTheme": "다크 모드에서 별도 테마 사용",
+        "lightModeTheme": "시스템이 라이트 모드일 때 사용할 테마",
+        "darkModeTheme": "시스템이 다크 모드일 때 사용할 테마",
         "customCss": "현재 테마에 적용할 사용자 정의 CSS",
         "spellcheckerEnabled": "맞춤법 검사가 활성화되어 있는지 여부",
         "spellcheckerNoUnderline": "맞춤법 오류에 밑줄을 그지 않음",
@@ -797,12 +799,15 @@
     "theme": {
       "title": "테마",
       "theme": "테마",
-      "followSystemTheme": "시스템 테마 따르기",
+      "followSystemTheme": "다크 모드에서 별도 테마 사용",
+      "modeThemes": "테마 선택",
+      "lightModeTheme": "라이트 모드 테마",
+      "darkModeTheme": "다크 모드 테마",
+      "customCss": "사용자 정의 CSS",
       "codeBlockTheme": {
         "title": "코드 블록 테마",
         "description": "코드 블록용 테마"
       },
-      "customCss": "사용자 정의 CSS",
       "importCustomThemes": "사용자 정의 테마 가져오기",
       "importTheme": "테마 가져오기",
       "openFolder": "폴더 열기",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "GitLab 호환 모드 활성화",
         "sequenceTheme": "시퀀스 다이어그램 테마",
         "theme": "MarkText에서 사용할 테마 선택",
-        "followSystemTheme": "다크 모드에서 별도 테마 사용",
+        "followSystemTheme": "시스템 테마 따르기",
         "lightModeTheme": "시스템이 라이트 모드일 때 사용할 테마",
         "darkModeTheme": "시스템이 다크 모드일 때 사용할 테마",
         "customCss": "현재 테마에 적용할 사용자 정의 CSS",
@@ -799,7 +799,7 @@
     "theme": {
       "title": "테마",
       "theme": "테마",
-      "followSystemTheme": "다크 모드에서 별도 테마 사용",
+      "followSystemTheme": "시스템 테마 따르기",
       "modeThemes": "테마 선택",
       "lightModeTheme": "라이트 모드 테마",
       "darkModeTheme": "다크 모드 테마",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -423,7 +423,9 @@
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidade GitLab",
         "sequenceTheme": "Tema do diagrama de sequência",
         "theme": "Selecionar o tema usado no MarkText",
-        "followSystemTheme": "Seguir tema do sistema (claro/escuro)",
+        "followSystemTheme": "Usar tema separado no modo escuro",
+        "lightModeTheme": "Tema a ser usado quando o sistema está no modo claro",
+        "darkModeTheme": "Tema a ser usado quando o sistema está no modo escuro",
         "customCss": "CSS personalizado para aplicar ao tema atual",
         "spellcheckerEnabled": "Se a verificação ortográfica está habilitada",
         "spellcheckerNoUnderline": "Não sublinhar erros ortográficos",
@@ -797,12 +799,15 @@
     "theme": {
       "title": "Tema",
       "theme": "Tema",
-      "followSystemTheme": "Seguir tema do sistema",
+      "followSystemTheme": "Usar tema separado no modo escuro",
+      "modeThemes": "Seleção de Tema",
+      "lightModeTheme": "Tema do modo claro",
+      "darkModeTheme": "Tema do modo escuro",
+      "customCss": "CSS Personalizado",
       "codeBlockTheme": {
         "title": "Tema do bloco de código",
         "description": "Tema para blocos de código"
       },
-      "customCss": "CSS Personalizado",
       "importCustomThemes": "Importar temas personalizados",
       "importTheme": "Importar Tema",
       "openFolder": "Abrir Pasta",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidade GitLab",
         "sequenceTheme": "Tema do diagrama de sequência",
         "theme": "Selecionar o tema usado no MarkText",
-        "followSystemTheme": "Usar tema separado no modo escuro",
+        "followSystemTheme": "Seguir tema do sistema",
         "lightModeTheme": "Tema a ser usado quando o sistema está no modo claro",
         "darkModeTheme": "Tema a ser usado quando o sistema está no modo escuro",
         "customCss": "CSS personalizado para aplicar ao tema atual",
@@ -799,7 +799,7 @@
     "theme": {
       "title": "Tema",
       "theme": "Tema",
-      "followSystemTheme": "Usar tema separado no modo escuro",
+      "followSystemTheme": "Seguir tema do sistema",
       "modeThemes": "Seleção de Tema",
       "lightModeTheme": "Tema do modo claro",
       "darkModeTheme": "Tema do modo escuro",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidade GitLab",
         "sequenceTheme": "Tema do diagrama de sequência",
         "theme": "Selecionar o tema usado no MarkText",
-        "autoSwitchTheme": "Ajustar automaticamente o tema da aplicação de acordo com o sistema",
+        "followSystemTheme": "Seguir tema do sistema (claro/escuro)",
         "customCss": "CSS personalizado para aplicar ao tema atual",
         "spellcheckerEnabled": "Se a verificação ortográfica está habilitada",
         "spellcheckerNoUnderline": "Não sublinhar erros ortográficos",
@@ -797,27 +797,12 @@
     "theme": {
       "title": "Tema",
       "theme": "Tema",
-      "autoSwitchTheme": {
-        "title": "Alternar tema automaticamente",
-        "description": "Alternar tema automaticamente baseado no sistema",
-        "followSystem": "Seguir sistema",
-        "light": "Claro",
-        "dark": "Escuro"
-      },
-      "realTime": {
-        "title": "Tempo real",
-        "description": "Alternância de tema em tempo real"
-      },
+      "followSystemTheme": "Seguir tema do sistema",
       "codeBlockTheme": {
         "title": "Tema do bloco de código",
         "description": "Tema para blocos de código"
       },
       "customCss": "CSS Personalizado",
-      "autoSwitchOptions": {
-        "startup": "Na inicialização",
-        "never": "Nunca"
-      },
-      "autoSwitch": "Alternar tema automaticamente",
       "importCustomThemes": "Importar temas personalizados",
       "importTheme": "Importar Tema",
       "openFolder": "Abrir Pasta",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -423,7 +423,9 @@
         "isGitlabCompatibilityEnabled": "启用 GitLab 兼容模式",
         "sequenceTheme": "序列图主题",
         "theme": "选择 MarkText 中使用的主题",
-        "followSystemTheme": "跟随系统主题(浅色/深色)",
+        "followSystemTheme": "在暗色模式下使用单独的主题",
+        "lightModeTheme": "系统处于浅色模式时使用的主题",
+        "darkModeTheme": "系统处于深色模式时使用的主题",
         "customCss": "应用到当前主题的自定义 CSS",
         "spellcheckerEnabled": "是否启用拼写检查",
         "spellcheckerNoUnderline": "不要为拼写错误添加下划线",
@@ -796,12 +798,15 @@
     "theme": {
       "title": "主题",
       "theme": "主题",
-      "followSystemTheme": "跟随系统主题",
+      "followSystemTheme": "在暗色模式下使用单独的主题",
+      "modeThemes": "主题选择",
+      "lightModeTheme": "浅色模式主题",
+      "darkModeTheme": "深色模式主题",
+      "customCss": "自定义 CSS",
       "codeBlockTheme": {
         "title": "代码块主题",
         "description": "代码块的主题"
       },
-      "customCss": "自定义 CSS",
       "importCustomThemes": "导入自定义主题",
       "importTheme": "导入主题",
       "openFolder": "打开文件夹",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "启用 GitLab 兼容模式",
         "sequenceTheme": "序列图主题",
         "theme": "选择 MarkText 中使用的主题",
-        "autoSwitchTheme": "根据系统自动调整应用程序主题",
+        "followSystemTheme": "跟随系统主题(浅色/深色)",
         "customCss": "应用到当前主题的自定义 CSS",
         "spellcheckerEnabled": "是否启用拼写检查",
         "spellcheckerNoUnderline": "不要为拼写错误添加下划线",
@@ -796,27 +796,12 @@
     "theme": {
       "title": "主题",
       "theme": "主题",
-      "autoSwitchTheme": {
-        "title": "自动切换主题",
-        "description": "根据系统自动切换主题",
-        "followSystem": "跟随系统",
-        "light": "浅色",
-        "dark": "深色"
-      },
-      "realTime": {
-        "title": "实时",
-        "description": "实时主题切换"
-      },
+      "followSystemTheme": "跟随系统主题",
       "codeBlockTheme": {
         "title": "代码块主题",
         "description": "代码块的主题"
       },
       "customCss": "自定义 CSS",
-      "autoSwitchOptions": {
-        "startup": "启动时",
-        "never": "从不"
-      },
-      "autoSwitch": "自动切换主题",
       "importCustomThemes": "导入自定义主题",
       "importTheme": "导入主题",
       "openFolder": "打开文件夹",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "启用 GitLab 兼容模式",
         "sequenceTheme": "序列图主题",
         "theme": "选择 MarkText 中使用的主题",
-        "followSystemTheme": "在暗色模式下使用单独的主题",
+        "followSystemTheme": "跟随系统主题",
         "lightModeTheme": "系统处于浅色模式时使用的主题",
         "darkModeTheme": "系统处于深色模式时使用的主题",
         "customCss": "应用到当前主题的自定义 CSS",
@@ -798,7 +798,7 @@
     "theme": {
       "title": "主题",
       "theme": "主题",
-      "followSystemTheme": "在暗色模式下使用单独的主题",
+      "followSystemTheme": "跟随系统主题",
       "modeThemes": "主题选择",
       "lightModeTheme": "浅色模式主题",
       "darkModeTheme": "深色模式主题",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "啟用 GitLab 相容模式",
         "sequenceTheme": "序列圖主題",
         "theme": "選擇 MarkText 中使用的主題",
-        "followSystemTheme": "在深色模式下使用單獨的主題",
+        "followSystemTheme": "跟隨系統主題",
         "lightModeTheme": "系統處於淺色模式時使用的主題",
         "darkModeTheme": "系統處於深色模式時使用的主題",
         "customCss": "套用到當前主題的自訂 CSS",
@@ -799,7 +799,7 @@
     "theme": {
       "title": "主題",
       "theme": "主題",
-      "followSystemTheme": "在深色模式下使用單獨的主題",
+      "followSystemTheme": "跟隨系統主題",
       "modeThemes": "主題選擇",
       "lightModeTheme": "淺色模式主題",
       "darkModeTheme": "深色模式主題",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -423,7 +423,9 @@
         "isGitlabCompatibilityEnabled": "啟用 GitLab 相容模式",
         "sequenceTheme": "序列圖主題",
         "theme": "選擇 MarkText 中使用的主題",
-        "followSystemTheme": "跟隨系統主題(淺色/深色)",
+        "followSystemTheme": "在深色模式下使用單獨的主題",
+        "lightModeTheme": "系統處於淺色模式時使用的主題",
+        "darkModeTheme": "系統處於深色模式時使用的主題",
         "customCss": "套用到當前主題的自訂 CSS",
         "spellcheckerEnabled": "是否啟用拼字檢查",
         "spellcheckerNoUnderline": "不要為拼字錯誤加上底線",
@@ -797,12 +799,15 @@
     "theme": {
       "title": "主題",
       "theme": "主題",
-      "followSystemTheme": "跟隨系統主題",
+      "followSystemTheme": "在深色模式下使用單獨的主題",
+      "modeThemes": "主題選擇",
+      "lightModeTheme": "淺色模式主題",
+      "darkModeTheme": "深色模式主題",
+      "customCss": "自訂 CSS",
       "codeBlockTheme": {
         "title": "程式碼區塊主題",
         "description": "程式碼區塊的主題"
       },
-      "customCss": "自訂 CSS",
       "importCustomThemes": "匯入自訂主題",
       "importTheme": "匯入主題",
       "openFolder": "開啟資料夾",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -423,7 +423,7 @@
         "isGitlabCompatibilityEnabled": "啟用 GitLab 相容模式",
         "sequenceTheme": "序列圖主題",
         "theme": "選擇 MarkText 中使用的主題",
-        "autoSwitchTheme": "根據系統自動調整應用程式主題",
+        "followSystemTheme": "跟隨系統主題(淺色/深色)",
         "customCss": "套用到當前主題的自訂 CSS",
         "spellcheckerEnabled": "是否啟用拼字檢查",
         "spellcheckerNoUnderline": "不要為拼字錯誤加上底線",
@@ -797,27 +797,12 @@
     "theme": {
       "title": "主題",
       "theme": "主題",
-      "autoSwitchTheme": {
-        "title": "自動切換主題",
-        "description": "根據系統自動切換主題",
-        "followSystem": "跟隨系統",
-        "light": "淺色",
-        "dark": "深色"
-      },
-      "realTime": {
-        "title": "即時",
-        "description": "即時主題切換"
-      },
+      "followSystemTheme": "跟隨系統主題",
       "codeBlockTheme": {
         "title": "程式碼區塊主題",
         "description": "程式碼區塊的主題"
       },
       "customCss": "自訂 CSS",
-      "autoSwitchOptions": {
-        "startup": "啟動時",
-        "never": "永不"
-      },
-      "autoSwitch": "自動切換主題",
       "importCustomThemes": "匯入自訂主題",
       "importTheme": "匯入主題",
       "openFolder": "開啟資料夾",

--- a/static/preference.json
+++ b/static/preference.json
@@ -52,7 +52,7 @@
   "sequenceTheme": "hand",
 
   "theme": "light",
-  "followSystemTheme": false,
+  "followSystemTheme": true,
   "lightModeTheme": "light",
   "darkModeTheme": "dark",
   "customCss": "",

--- a/static/preference.json
+++ b/static/preference.json
@@ -52,7 +52,7 @@
   "sequenceTheme": "hand",
 
   "theme": "light",
-  "autoSwitchTheme": 2,
+  "followSystemTheme": false,
   "customCss": "",
 
   "spellcheckerEnabled": false,

--- a/static/preference.json
+++ b/static/preference.json
@@ -53,6 +53,8 @@
 
   "theme": "light",
   "followSystemTheme": false,
+  "lightModeTheme": "light",
+  "darkModeTheme": "dark",
   "customCss": "",
 
   "spellcheckerEnabled": false,


### PR DESCRIPTION
## Follow system theme, Light/Dark Mode Theme Selection

### Summary

Adds the ability to select different themes for light and dark system modes, with automatic switching when the system theme changes. This replaces the previous "Auto switch theme" dropdown with a more intuitive toggle and separate theme selectors. Fixes #42 

### Features

- **Separate theme selection**: Choose any theme for light mode and any theme for dark mode (e.g., Graphite + Material Dark)
- **Immediate switching**: Theme changes apply instantly when system theme changes or preferences are toggled
- **No startup flash**: Fixed white flash on Linux by waiting for theme system to initialize
- **Better UX**: Replaced confusing enum dropdown with simple toggle + dropdowns

### Changes

- Runtime theme switching now works without restart
- Window background color matches selected theme from startup (no flash)

###  Config Migration

`autoSwitchTheme` preference replaced with `followSystemTheme` + `lightModeTheme` + `darkModeTheme`. Existing settings are automatically migrated.

### Files Changed

**Core files (8):**

- `src/main/app/index.js` - Theme switching logic
- `src/main/preferences/schema.json` - New preferences
- `src/main/preferences/index.js` - Migration logic
- `src/renderer/src/prefComponents/theme/config.js`

- `src/renderer/src/prefComponents/theme/index.vue` - UI
- `src/renderer/src/store/preferences.js` - State management
- `static/preference.json` - Defaults

**Translation files (9):**
de, en, es, fr, ja, ko, pt, zh-CN, zh-TW

### Testing

Tested on Linux/Arch (Niri) and minimal testing in Windows 11 vm. Needs testing on OSX

# NOTE

Javascript is not a strength of mine! The minimal programming I do is usually lua, python and a little golang. So code quality might be lacking. But after a fair amount of testing on linux this appears to work well and really would be a net positive to marktext imho. The option to follow the system theme without a restart is a standard in most programs nowadays. All non-english translation files were done with claude, so no guarantees regarding accuracy.


https://github.com/user-attachments/assets/b909671a-098d-415b-9abf-c6fff4328dcd

