### PR TITLE
Fix macOS app launch issues with ad-hoc signing

### DIFF
--- a/build/mac/entitlements.mac.plist
+++ b/build/mac/entitlements.mac.plist
@@ -8,5 +8,9 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
   </dict>
 </plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -73,6 +73,7 @@ nsis:
   include: windows/installer.nsh
 mac:
   artifactName: 'marktext-mac-${arch}-${version}.${ext}'
+  entitlements: build/mac/entitlements.mac.plist
   entitlementsInherit: build/mac/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.


### PR DESCRIPTION
## Summary
- Add missing entitlements required for Electron's crashpad to work properly on macOS when the app is ad-hoc signed (not notarized)
- Add the `entitlements` config to electron-builder so entitlements are applied to the main app bundle, not just inherited by child processes

## Problem
When building MarkText without an Apple Developer certificate, the app is ad-hoc signed. On recent macOS versions, the app would bounce in the dock but never open a window, with crashpad errors like:
```
[FATAL:crashpad/handler/mac/exception_handler_server.cc:76] Check failed: kr == KERN_SUCCESS. mach_port_request_notification: (os/kern) invalid capability (20)
```

## Solution
Added two entitlements to `build/mac/entitlements.mac.plist`:
- `com.apple.security.cs.disable-library-validation`
- `com.apple.security.get-task-allow`

And configured electron-builder to apply these entitlements to the main app bundle.

## Testing
1. Build the app: `npm run build:mac`
2. Install WITHOUT running `xattr -cr` or manual `codesign`
3. Launch the app - it should open without bouncing/crashing
4. Verify entitlements: `codesign -d --entitlements - dist/mac-arm64/marktext.app`

🤖 Generated with [Claude Code](https://claude.ai/code)