### PR TITLE
Add file associations for macOS

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -52,6 +52,37 @@ electronLanguages: # Avoid packaging all chromium locales since our app has in-b
 
 asarUnpack:
   - resources/**
+fileAssociations:
+  - ext: md
+    name: Markdown
+    description: Markdown document
+    mimeType: text/markdown
+    role: Editor
+  - ext: markdown
+    name: Markdown
+    description: Markdown document
+    mimeType: text/markdown
+    role: Editor
+  - ext: mmd
+    name: Markdown
+    description: Markdown document
+    mimeType: text/markdown
+    role: Editor
+  - ext: mdown
+    name: Markdown
+    description: Markdown document
+    mimeType: text/markdown
+    role: Editor
+  - ext: mdtxt
+    name: Markdown
+    description: Markdown document
+    mimeType: text/markdown
+    role: Editor
+  - ext: mdtext
+    name: Markdown
+    description: Markdown document
+    mimeType: text/markdown
+    role: Editor
 win:
   executableName: marktext
   artifactName: 'marktext-win-${arch}-${version}.${ext}'


### PR DESCRIPTION
## Summary
Register MarkText as a handler for markdown files on macOS, allowing users to set it as the default app for opening markdown files.

## Changes
Added `fileAssociations` to `electron-builder.yml` for the following extensions:
- `.md`
- `.markdown`
- `.mmd`
- `.mdown`
- `.mdtxt`
- `.mdtext`

## Result
- MarkText appears in Finder's "Open With" context menu for markdown files
- Users can set MarkText as the default app via "Get Info" → "Open with" → "Change All..."

## Testing
1. Build the app: `npm run build:mac`
2. Install the app
3. Right-click a `.md` file in Finder
4. Verify MarkText appears in "Open With" menu
5. Optionally set as default via Get Info

🤖 Generated with [Claude Code](https://claude.ai/code)