### PR TITLE
Fix: handle CodeMirror race condition error gracefully

### DIFF
--- a/src/renderer/src/util/index.js
+++ b/src/renderer/src/util/index.js
@@ -47,13 +47,20 @@ export const dataURItoBlob = function (dataURI) {
 }
 
 export const adjustCursor = (cursor, preline, line, nextline) => {
+  // Return null if line doesn't exist (e.g., cursor beyond document bounds)
+  if (typeof line !== 'string') {
+    return null
+  }
+
   let newCursor = Object.assign({}, { line: cursor.line, ch: cursor.ch })
   // It's need to adjust the cursor when cursor is at begin or end in table row.
   if (/\|[^|]+\|.+\|\s*$/.test(line)) {
     if (/\|\s*:?-+:?\s*\|[:-\s|]+\|\s*$/.test(line)) {
       // cursor in `| --- | :---: |` :the second line of table
-      newCursor.line += 1 // reset the cursor to the next line
-      newCursor.ch = nextline.indexOf('|') + 1
+      if (typeof nextline === 'string') {
+        newCursor.line += 1 // reset the cursor to the next line
+        newCursor.ch = nextline.indexOf('|') + 1
+      }
     } else {
       // cursor is not at the second line to table
       if (cursor.ch <= line.indexOf('|')) newCursor.ch = line.indexOf('|') + 1


### PR DESCRIPTION
## Summary

- Add defensive handling for a known CodeMirror 5 race condition that causes `TypeError: Cannot read properties of undefined (reading 'map')` errors when clicking in the source code editor during rapid state changes
- Add null check in `adjustCursor()` for when `cm.getLine()` returns null (cursor beyond document bounds)
- Suppress non-fatal CodeMirror errors instead of showing an error dialog to the user

## Root Cause

This is a known Vue/CodeMirror 5 compatibility issue where Vue's reactive proxy system can interfere with CodeMirror's internal line measurement data structures during mouse click handling.

See: https://github.com/codemirror/codemirror5/issues/6886

## Error Stack Trace (before fix)

```
TypeError: Cannot read properties of undefined (reading 'map')
    at prepareMeasureForLine
    at coordsCharInner
    at coordsChar
    at posFromMouse
    at CodeMirror.onMouseDown
```

## Test Plan

- [x] Build completes successfully
- [ ] Click rapidly in source code editor - should no longer show error dialog
- [ ] Switch between files while clicking - should handle gracefully