### PR TITLE
feat(windows): support displaying and opening .lnk shortcut files

### DIFF
--- a/src/common/filesystem/paths.js
+++ b/src/common/filesystem/paths.js
@@ -2,8 +2,10 @@ import fs from 'fs'
 import path from 'path'
 import { isFile, isFile2, isSymbolicLink } from './index'
 import { minimatch } from 'minimatch'
+import { shell } from 'electron'
 
 const isOsx = process.platform === 'darwin'
+const isWindows = process.platform === 'win32'
 
 export const MARKDOWN_EXTENSIONS = Object.freeze([
   'markdown',
@@ -30,7 +32,7 @@ export const IMAGE_EXTENSIONS = Object.freeze(['jpeg', 'jpg', 'png', 'gif', 'svg
  */
 export const hasMarkdownExtension = (filename) => {
   if (!filename || typeof filename !== 'string') return false
-  return MARKDOWN_EXTENSIONS.some((ext) => filename.toLowerCase().endsWith(`.${ext}`))
+  return MARKDOWN_EXTENSIONS.some((ext) => resolveShortcut(filename).toLowerCase().endsWith(`.${ext}`))
 }
 
 /**
@@ -132,4 +134,20 @@ export const checkPathExcludePattern = (pathname, patterns) => {
     }
   }
   return false
+}
+
+/**
+ * Returns the actual path pointed to by a shortcut file, or the original path if resolution fails.
+ * @param {string} The absolute path of the shortcut file.
+ */
+export const resolveShortcut = (shortcutPath) => {
+  try {
+    if (isWindows) {
+      return shell.readShortcutLink(shortcutPath)?.target || shortcutPath
+    } else {
+      return shortcutPath
+    }
+  } catch {
+    return shortcutPath
+  }
 }

--- a/src/main/filesystem/markdown.js
+++ b/src/main/filesystem/markdown.js
@@ -4,7 +4,7 @@ import log from 'electron-log'
 import iconv from 'iconv-lite'
 import { LINE_ENDING_REG, LF_LINE_ENDING_REG, CRLF_LINE_ENDING_REG } from '../config'
 import { isDirectory2 } from 'common/filesystem'
-import { isMarkdownFile } from 'common/filesystem/paths'
+import { isMarkdownFile, resolveShortcut } from 'common/filesystem/paths'
 import { normalizeAndResolvePath, writeFile } from '../filesystem'
 import { guessEncoding } from './encoding'
 
@@ -87,7 +87,7 @@ export const loadMarkdownFile = async (
   // TODO: Use streams to not buffer the file multiple times and only guess
   //       encoding on the first 256/512 bytes.
 
-  let buffer = await fsPromises.readFile(path.resolve(pathname))
+  let buffer = await fsPromises.readFile(path.resolve(resolveShortcut(pathname)))
 
   const encoding = guessEncoding(buffer, autoGuessEncoding)
   const supported = iconv.encodingExists(encoding.encoding)


### PR DESCRIPTION
feat(windows): support displaying and opening .lnk shortcut files

Allow MarkText to show Windows shortcut (.lnk) files in the sidebar file tree and resolve them to their target files when opened. This enhancement treats shortcuts as if they were the actual files, improving the Windows experience.

### Key changes:
- Add "resolveShortcut" helper function that parses .lnk files and returns the resolved target path (or the original path if resolution fails)
- In the sidebar file tree, filter .lnk files by checking whether the resolved target's extension is included in "MARKDOWN_EXTENSIONS"; only display those that point to supported file types
- Update file opening logic to call "resolveShortcut" on the given path before reading the file with "fsPromises.readFile" in "loadMarkdownFile", ensuring the actual target content is loaded

### Screenshots
This screenshot shows ".lnk" shortcut files now appearing in the sidebar and successfully opening the target Markdown document.  

<img width="446" height="393" alt="image" src="https://github.com/user-attachments/assets/89a39f66-8188-438c-aa18-924833093948" />
