### PR TITLE
(Documentation) Cleaned up Linux installation instructions

### DIFF
--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -2,7 +2,7 @@
 
 ## AppImage
 
-[Download the AppImage](https://github.com/marktext/marktext/releases/latest) and type the following:
+[Download the AppImage](https://github.com/Tkaixiang/marktext/releases/latest) and type the following:
 
 1. `chmod +x marktext-%version%-x86_64.AppImage`
 2. `./marktext-%version%-x86_64.AppImage`
@@ -52,48 +52,18 @@ You can integrate the AppImage into the system via [AppImageLauncher](https://gi
 
 ## Binary
 
-You can download the latest `marktext-%version%.tar.gz` package from the [release page](https://github.com/marktext/marktext/releases/latest). You may need to install electron dependencies.
-
-## Flatpak
-
-### Installation
-
-**Prerequisites:**
-
-You need to install the `flatpak` package for your distribution. Please see the [official flatpak tutorial](https://flatpak.org/setup/) for more information and note that you have to add the flathub repository (`flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo`) as described in the Quick Setup.
-
-**Install from Flathub:**
-
-After you install flatpak and flathub repository, you can install [MarkText](https://flathub.org/apps/details/com.github.marktext.marktext) with just one command (note that you may be asked to enter your password):
-
-```
-flatpak install flathub com.github.marktext.marktext
-```
-
-or `flatpak install --user flathub com.github.marktext.marktext` to install for the current user only.
-
-To run MarkText just execute `flatpak run com.github.marktext.marktext` or click on the MarkText icon in your application launcher.
-
-### Update
-
-To update MarkText run the following command:
-
-```
-flatpak update com.github.marktext.marktext
-```
-
-or `flatpak update` to update all installed flatpaks.
+You can download the latest `marktext-%version%.tar.gz` package from the [release page](https://github.com/Tkaixiang/marktext/releases/latest). You may need to install electron dependencies.
 
 ## Arch User Repository
 
-The Arch User Repository also contains the packages:
+Marktext is available on the AUR as `marktext-tkaixiang-bin` and will automatically install the dependencies: `glibc`, `gtk3`, `nss`, `alsa-lib`, `libxss`, `cups`, `libxkbcommon`, `libxkbfile`, `mesa`, and `hicolor-icon-theme`. 
 
-`marktext`, `marktext-bin`, `marktext-git`, `marktext-appimage`, `electron15-bin` and `ripgrep`.
+Install it via an AUR helper like `yay -S marktext-tkaixiang-bin` or with
 
-Install it via an AUR helper like `yay -S marktext` or with
-
-```
+```bash
 git clone https://aur.archlinux.org/marktext.git
-cd marktext
+cd marktext-tkaixiang-bin
 makepkg -si
 ```
+
+Note: The AUR package is not maintained by the maintainer of this repository and may be out of date. Take note of the version numbers and modify the PKGBUILD on the AUR as necessary before installation or update.


### PR DESCRIPTION
Removed Flatpak install instructions, as they point to the original release, not this fork of Marktext and this version is not available on Flathub.

Updated Arch User Repository installation instructions to point to this fork of Marktext, rather than the original. Added disclaimer about the AUR package not being maintained by the maintainer of this repository, so it may be out of date. Updated list of dependencies for AUR package installation.

Updated links to point to the correct releases page for this repository.