### PR TITLE
Address PR #4001 review feedback (static path, appId, i18n loop, electron-log)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,4 +1,4 @@
-appId: com.electron.app
+appId: com.github.marktext.marktext
 productName: marktext
 directories:
   buildResources: build

--- a/src/common/i18n.js
+++ b/src/common/i18n.js
@@ -58,10 +58,10 @@ function getTranslation(key, language = 'en', params = {}) {
   const keys = key.split('.')
   let probe = translations
 
-  for (key of keys) {
+  for (const segment of keys) {
     // Navigate through nested objects until the string
-    if (key in probe) {
-      probe = probe[key]
+    if (probe && segment in probe) {
+      probe = probe[segment]
     } else {
       return key // Unable to find key, return the key itself
     }

--- a/src/common/i18n.js
+++ b/src/common/i18n.js
@@ -54,13 +54,17 @@ function loadTranslations(language) {
 function getTranslation(key, language = 'en', params = {}) {
   const translations = loadTranslations(language)
 
+  if (!translations) {
+    return key
+  }
+
   // 支持点分隔的嵌套键
   const keys = key.split('.')
   let probe = translations
 
   for (const segment of keys) {
     // Navigate through nested objects until the string
-    if (probe && segment in probe) {
+    if (segment in probe) {
       probe = probe[segment]
     } else {
       return key // Unable to find key, return the key itself

--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -130,7 +130,7 @@ class App {
       // 如果没有设置语言，则根据系统语言自动设置
       if (!currentLanguage) {
         const systemLanguage = app.getLocale()
-        console.log(`System language detected: ${systemLanguage}`)
+        log.info(`System language detected: ${systemLanguage}`)
 
         // 支持的语言列表（根据项目实际支持的语言）
         const supportedLanguages = [
@@ -180,13 +180,13 @@ class App {
 
         // 保存检测到的语言设置
         this._accessor.preferences.setItem('language', currentLanguage)
-        console.log(`Auto-detected and set language to: ${currentLanguage}`)
+        log.info(`Auto-detected and set language to: ${currentLanguage}`)
       }
 
       setLanguage(currentLanguage)
-      console.log(`Main process language initialized to: ${currentLanguage}`)
+      log.info(`Main process language initialized to: ${currentLanguage}`)
     } catch (error) {
-      console.error('Failed to initialize main process language:', error)
+      log.error('Failed to initialize main process language:', error)
       // 如果出错，使用英语作为默认语言
       setLanguage('en')
     }

--- a/src/main/globalSetting.js
+++ b/src/main/globalSetting.js
@@ -3,5 +3,5 @@ import { app } from 'electron'
 
 // Set `__static` path to static files in production / development depending on the environment
 global.__static = path
-  .join(app.isPackaged ? process.resourcesPath : process.cwd(), 'static')
+  .join(app.isPackaged ? process.resourcesPath : app.getAppPath(), 'static')
   .replace(/\\/g, '\\\\')


### PR DESCRIPTION
## Summary

Addresses four items from Jocs's review on marktext/marktext#4001:

- **`src/main/globalSetting.js`** — switch `__static` dev path from `process.cwd()` to `app.getAppPath()`. `process.cwd()` is the launch directory, so if the binary was invoked from anywhere other than the repo root, `__static` silently pointed at a non-existent `static/`. `app.getAppPath()` is anchored to the app itself.
- **`electron-builder.yml`** — restore `appId` to `com.github.marktext.marktext`. The template default `com.electron.app` would collide with other Electron apps and break auto-updates / macOS Keychain entries for existing users.
- **`src/common/i18n.js`** — `getTranslation` was using `for (key of keys)` which reassigns the outer `key` parameter. On a miss the fallback `return key` returned the last-iterated segment instead of the original full key. Renamed the loop variable to `segment` and added a null-guard on `probe`.
- **`src/main/app/index.js`** — `_initializeLanguage` now logs via `electron-log` (already imported) instead of `console.log` / `console.error`, so language-init diagnostics land in the same log stream as the rest of the main process.

## Test plan

- [ ] `yarn dev` from the repo root: app launches, `__static` resolves to `<repo>/static`
- [ ] `yarn dev` invoked from a different cwd: `__static` still resolves to `<repo>/static`
- [ ] Packaged build: `__static` resolves under `resourcesPath` (unchanged behavior)
- [ ] First-run language detection: log lines appear in the electron-log output
- [ ] `getTranslation('nonexistent.deeply.nested.key')` returns the original full string, not `'key'`
- [ ] Packaged installer uses `com.github.marktext.marktext` as the app identifier

Out of scope for this PR (will need separate changes): `nodeIntegration`, preload API surface, watcher hidden-dir ignore, restored tests, restored community docs, Chinese-comment cleanup, `handleResponseForSave` signature.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gacqxi6y3qRyvVVmbqFsQr)_